### PR TITLE
Enhance create entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'groovy'
 
-version = '0.9.1'
+version = '0.10.0'
 
 //Get dependencies from Maven central repository
 repositories {

--- a/src/main/groovy/com/canonicalidentity/directoryservice/DirectoryServiceEntry.groovy
+++ b/src/main/groovy/com/canonicalidentity/directoryservice/DirectoryServiceEntry.groovy
@@ -191,7 +191,7 @@ class DirectoryServiceEntry implements Serializable {
      * Constructs a new DirectoryServiceEntry object from the passed in Entry
      * {@code entry}, and uses the passed in singular {@code ditItem} and
      * updates the passed in entry based on the base DN, rdnAttribute, and
-     * objectClass values in found in the ditMap associated with the
+     * objectClass values found in the ditMap associated with the
      * {@code ditItem}.
      *
      * The returned object can then be used just like any DirectoryServiceEntry

--- a/src/test/groovy/com/canonicalidentity/directoryservice/DirectoryServiceEntryEntryTests.groovy
+++ b/src/test/groovy/com/canonicalidentity/directoryservice/DirectoryServiceEntryEntryTests.groovy
@@ -150,6 +150,25 @@ class DirectoryServiceEntryEntryTests extends GroovyTestCase {
         assertEquals entry.baseDN, 'ou=people,dc=someu,dc=edu'
     }
 
+    void testNewEntryWorksWithPassedInEntryAndDitItem() {
+        def ubidEntry = new Entry(
+            'dn: cn=testing,ou=something...,dc=someu,dc=edu',
+            'uid: testing',
+            'objectClass: something',
+            'objectClass: somethingElse'
+        )
+
+        def entry = new DirectoryServiceEntry(ubidEntry, 'person', directoryService)
+        assertNotNull entry
+        assertEquals entry.baseDN, 'ou=people,dc=someu,dc=edu'
+        assertEquals entry.dn, 'uid=testing,ou=people,dc=someu,dc=edu'
+        
+        def objectClasses = entry.entry.getAttributeValues('objectClass')
+        assertFalse objectClasses.contains('something')
+        assertFalse objectClasses.contains('somethingElse')
+        assertEquals objectClasses.size(), 4
+    }
+
     void testNewEntryFailsWhenPassedInEntryHasInvalidDN() {
         def ubidEntry = new Entry('uid=testing,ou=blah,dc=someu,dc=edu')
 


### PR DESCRIPTION
New constructor for DirectoryServiceEntry to create a new object from a passed in Entry and uses the passed in singular `ditItem` and updates the passed in entry based on the base DN, `rdnAttribute`, and `objectClass` values found in the `ditMap` associated with the ditItem`.